### PR TITLE
Chore: use nnc option in invocation call

### DIFF
--- a/packages/homestar/src/workflow/index.js
+++ b/packages/homestar/src/workflow/index.js
@@ -280,7 +280,7 @@ export function invocation(opts) {
         args: opts.args,
         func: opts.func,
       },
-      nnc: '',
+      nnc: opts.nnc ?? '',
       op: 'wasm/run',
       rsc: opts.resource,
     },

--- a/packages/homestar/src/workflow/types.ts
+++ b/packages/homestar/src/workflow/types.ts
@@ -47,12 +47,14 @@ export interface TemplateInvocation<Args extends any[] = any[]>
 export type Placeholder = `{{${string}${`:${string}` | ''}}}`
 export type DataURI = `data:${string};base64,${string}`
 export type Resource = `ipfs://${string}`
+export type NNC = string | { '/': { bytes: string } }
 
 export interface InvocationOptions<Args extends any[] = any[]> {
   name: string
   args: Args
   func: string
   resource: Resource
+  nnc?: NNC
 }
 
 export interface TemplateOptions<
@@ -60,6 +62,7 @@ export interface TemplateOptions<
 > {
   name: string
   args: Args
+  nnc?: NNC
   /**
    * The resource URI to use for the invocation.
    *


### PR DESCRIPTION
# Description

I noticed `hs.runWorkflow` would hang when submitting a workflow with populated nonces that also use `{{needs.funcName.output}}`. Turns out the `nnc` wasn't actually being used in `invocation()`. Strangely though it works if you submit a raw workflow without `{{needs.funcName.output}}`. 

## Note
This isn't ready to merge yet because I'm still testing, but I wanted to open a draft PR in case I don't get it wrapped up today @hugomrdias 

## Link to issue

https://github.com/everywhere-computer/every-cli/issues/7

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Refactor (non-breaking change that updates existing functionality)
