### PR TITLE
Avivash/add node method

### DIFF
--- a/packages/homestar/readme.md
+++ b/packages/homestar/readme.md
@@ -69,3 +69,4 @@ conditions.
 
 [apache]: https://www.apache.org/licenses/LICENSE-2.0
 [mit]: http://opensource.org/licenses/MIT
+

--- a/packages/homestar/src/index.js
+++ b/packages/homestar/src/index.js
@@ -21,6 +21,7 @@ import * as T from './types.js'
  * @typedef {T.HomestarEvents} HomestarEvents
  * @typedef {T.HomestarOptions} HomestarOptions
  * @typedef {T.Metrics} Metrics
+ * @typedef {T.Node} Node
  * @typedef {T.Health} Health
  * @typedef {T.WorkflowNotification} WorkflowNotification
  * @typedef {T.EventNotification} EventNotification
@@ -88,6 +89,15 @@ export class Homestar extends Emittery {
   async metrics() {
     return this.#channel.request({
       method: 'metrics',
+    })
+  }
+
+  /**
+   * Homestar Node info
+   */
+  async node() {
+    return this.#channel.request({
+      method: 'node',
     })
   }
 

--- a/packages/homestar/src/schemas.js
+++ b/packages/homestar/src/schemas.js
@@ -4,6 +4,7 @@ import { CID as _CID } from 'multiformats/cid'
 /**
  * @typedef {import('zod').z.infer<typeof Receipt>} Receipt
  * @typedef {import('zod').z.infer<typeof Metrics>} Metrics
+ * @typedef {import('zod').z.infer<typeof Node>} Node
  * @typedef {import('zod').z.infer<typeof Health>} Health
  * @typedef {import('zod').z.infer<typeof Invocation>} Invocation
  * @typedef {import('zod').z.infer<typeof Task>} Task
@@ -30,10 +31,11 @@ export const Metrics = z.object({
 
 export const Health = z.object({
   healthy: z.boolean(),
-  // nodeInfo: z.object({
-  //   static: z.object({ peer_id: z.string() }),
-  //   dynamic: z.object({ listeners: z.array(z.string()) }),
-  // }),
+})
+
+export const Node = z.object({
+  static: z.object({ peer_id: z.string() }),
+  dynamic: z.object({ listeners: z.array(z.string()) }),
 })
 
 export const CID = /** @type {typeof z.custom<import('multiformats').CID>} */ (

--- a/packages/homestar/src/types.ts
+++ b/packages/homestar/src/types.ts
@@ -31,6 +31,7 @@ export interface Receipt<Out> extends Schemas.Receipt {
 export type HomestarService = Service<
   [
     IO<{ method: 'metrics' }, Schemas.Metrics>,
+    IO<{ method: 'node' }, Schemas.Node>,
     IO<{ method: 'health' }, Schemas.Health>,
     IO<{ method: 'subscribe_run_workflow'; params: Workflow[] }, string>,
     IO<{ method: 'subscribe_network_events' }, string>,

--- a/packages/homestar/test/homestar.test.js
+++ b/packages/homestar/test/homestar.test.js
@@ -54,6 +54,30 @@ test(
 )
 
 test(
+  'should fetch node info from homestar',
+  async function () {
+    const hs = new Homestar({
+      transport: new WebsocketTransport(HS1_URL, {
+        ws: WebSocket,
+      }),
+    })
+
+    const { error, result } = await hs.node()
+
+    if (error) {
+      return assert.fail(error)
+    }
+
+    assert.ok(typeof result.static.peer_id === 'string')
+    assert.ok(Array.isArray(result.dynamic.listeners))
+    hs.close()
+  },
+  {
+    timeout: 30_000,
+  }
+)
+
+test(
   'should fetch health from homestar',
   async function () {
     const hs = new Homestar({
@@ -69,9 +93,7 @@ test(
     }
 
     assert.equal(result.healthy, true)
-    // assert.ok(result.nodeInfo)
-    // assert.ok(typeof result.nodeInfo.static.peer_id === 'string')
-    // assert.ok(Array.isArray(result.nodeInfo.dynamic.listeners))
+
     hs.close()
   },
   {


### PR DESCRIPTION
# Description

Adding a method to fetch homestar `node` info so we can show the peer ID in the CP again. it used to be part of the `health` call, but it's been moved to its own endpoint now

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor (non-breaking change that updates existing functionality)
